### PR TITLE
feat(profile): implement Address and UserProfile modules with full application flow

### DIFF
--- a/User-Profile-Service/pom.xml
+++ b/User-Profile-Service/pom.xml
@@ -100,6 +100,17 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.6.3</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct-processor</artifactId>
+			<version>1.6.3</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>
@@ -123,6 +134,10 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/command/CreateAddressCommand.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/command/CreateAddressCommand.java
@@ -1,0 +1,11 @@
+package com.axconstantino.profile.application.address.command;
+
+import com.axconstantino.profile.domain.entities.Address;
+
+public record CreateAddressCommand(Address newAddress) {
+    public CreateAddressCommand {
+        if (newAddress == null) {
+            throw new IllegalArgumentException("New address cannot be null");
+        }
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/command/UpdateAddressCommand.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/command/UpdateAddressCommand.java
@@ -1,0 +1,16 @@
+package com.axconstantino.profile.application.address.command;
+
+import com.axconstantino.profile.domain.entities.Address;
+
+import java.util.UUID;
+
+public record UpdateAddressCommand(UUID existingAddressId, Address updatedAddress) {
+    public UpdateAddressCommand {
+        if (existingAddressId == null) {
+            throw new IllegalArgumentException("Address ID cannot be null");
+        }
+        if (updatedAddress == null) {
+            throw new IllegalArgumentException("Updated address cannot be null");
+        }
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/CreateAddressService.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/CreateAddressService.java
@@ -1,0 +1,18 @@
+package com.axconstantino.profile.application.address.service;
+
+import com.axconstantino.profile.application.address.command.CreateAddressCommand;
+import com.axconstantino.profile.application.address.usecase.CreateAddress;
+import com.axconstantino.profile.domain.repositories.AddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateAddressService implements CreateAddress {
+    private final AddressRepository addressRepository;
+
+    @Override
+    public void execute(CreateAddressCommand command) {;
+        addressRepository.save(command.newAddress());
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/CreateAddressService.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/CreateAddressService.java
@@ -5,12 +5,14 @@ import com.axconstantino.profile.application.address.usecase.CreateAddress;
 import com.axconstantino.profile.domain.repositories.AddressRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class CreateAddressService implements CreateAddress {
     private final AddressRepository addressRepository;
 
+    @Transactional
     @Override
     public void execute(CreateAddressCommand command) {;
         addressRepository.save(command.newAddress());

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/DeleteAddressByIdAndUserProfileIdService.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/DeleteAddressByIdAndUserProfileIdService.java
@@ -1,0 +1,19 @@
+package com.axconstantino.profile.application.address.service;
+
+import com.axconstantino.profile.application.address.usecase.DeleteByAddressIdAndUserProfileId;
+import com.axconstantino.profile.domain.repositories.AddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteAddressByIdAndUserProfileIdService implements DeleteByAddressIdAndUserProfileId {
+    private final AddressRepository addressRepository;
+
+    @Override
+    public void execute(UUID addressId, UUID userProfileId) {
+        addressRepository.deleteByIdAndUserProfileId(addressId, userProfileId);
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/DeleteAddressByIdAndUserProfileIdService.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/DeleteAddressByIdAndUserProfileIdService.java
@@ -4,6 +4,7 @@ import com.axconstantino.profile.application.address.usecase.DeleteByAddressIdAn
 import com.axconstantino.profile.domain.repositories.AddressRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -12,6 +13,7 @@ import java.util.UUID;
 public class DeleteAddressByIdAndUserProfileIdService implements DeleteByAddressIdAndUserProfileId {
     private final AddressRepository addressRepository;
 
+    @Transactional
     @Override
     public void execute(UUID addressId, UUID userProfileId) {
         addressRepository.deleteByIdAndUserProfileId(addressId, userProfileId);

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/DeleteAddressService.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/DeleteAddressService.java
@@ -1,0 +1,19 @@
+package com.axconstantino.profile.application.address.service;
+
+import com.axconstantino.profile.application.address.usecase.DeleteAddress;
+import com.axconstantino.profile.domain.repositories.AddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteAddressService implements DeleteAddress {
+    private final AddressRepository addressRepository;
+
+    @Override
+    public void execute(UUID addressId) {
+        addressRepository.delete(addressId);
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/DeleteAddressService.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/DeleteAddressService.java
@@ -4,6 +4,7 @@ import com.axconstantino.profile.application.address.usecase.DeleteAddress;
 import com.axconstantino.profile.domain.repositories.AddressRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -12,6 +13,7 @@ import java.util.UUID;
 public class DeleteAddressService implements DeleteAddress {
     private final AddressRepository addressRepository;
 
+    @Transactional
     @Override
     public void execute(UUID addressId) {
         addressRepository.delete(addressId);

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/GetAddress.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/GetAddress.java
@@ -1,0 +1,20 @@
+package com.axconstantino.profile.application.address.service;
+
+import com.axconstantino.profile.application.address.usecase.GetAddressById;
+import com.axconstantino.profile.domain.entities.Address;
+import com.axconstantino.profile.domain.repositories.AddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GetAddress implements GetAddressById {
+    private final AddressRepository getAddressById;
+
+    @Override
+    public Address execute(UUID id) {
+        return getAddressById.findById(id);
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/GetAddress.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/GetAddress.java
@@ -5,6 +5,7 @@ import com.axconstantino.profile.domain.entities.Address;
 import com.axconstantino.profile.domain.repositories.AddressRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -13,6 +14,7 @@ import java.util.UUID;
 public class GetAddress implements GetAddressById {
     private final AddressRepository getAddressById;
 
+    @Transactional
     @Override
     public Address execute(UUID id) {
         return getAddressById.findById(id);

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/GetAllAddresses.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/GetAllAddresses.java
@@ -1,0 +1,21 @@
+package com.axconstantino.profile.application.address.service;
+
+import com.axconstantino.profile.application.address.usecase.GetAllAddressesByUserProfileId;
+import com.axconstantino.profile.domain.entities.Address;
+import com.axconstantino.profile.domain.repositories.AddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GetAllAddresses implements GetAllAddressesByUserProfileId {
+    private final AddressRepository addressRepository;
+
+    @Override
+    public List<Address> execute(UUID userProfileId) {
+        return addressRepository.findAllByUserProfileId(userProfileId);
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/GetAllAddresses.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/GetAllAddresses.java
@@ -5,6 +5,7 @@ import com.axconstantino.profile.domain.entities.Address;
 import com.axconstantino.profile.domain.repositories.AddressRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -14,6 +15,7 @@ import java.util.UUID;
 public class GetAllAddresses implements GetAllAddressesByUserProfileId {
     private final AddressRepository addressRepository;
 
+    @Transactional
     @Override
     public List<Address> execute(UUID userProfileId) {
         return addressRepository.findAllByUserProfileId(userProfileId);

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/GetSpecificAddress.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/GetSpecificAddress.java
@@ -1,0 +1,20 @@
+package com.axconstantino.profile.application.address.service;
+
+import com.axconstantino.profile.application.address.usecase.GetAddressByIdAndUserProfileId;
+import com.axconstantino.profile.domain.entities.Address;
+import com.axconstantino.profile.domain.repositories.AddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GetSpecificAddress implements GetAddressByIdAndUserProfileId {
+    private final AddressRepository addressRepository;
+
+    @Override
+    public Address execute(UUID id, UUID userProfileId) {
+        return addressRepository.findByIdAndUserProfileId(id, userProfileId);
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/GetSpecificAddress.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/GetSpecificAddress.java
@@ -5,6 +5,7 @@ import com.axconstantino.profile.domain.entities.Address;
 import com.axconstantino.profile.domain.repositories.AddressRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -13,6 +14,7 @@ import java.util.UUID;
 public class GetSpecificAddress implements GetAddressByIdAndUserProfileId {
     private final AddressRepository addressRepository;
 
+    @Transactional
     @Override
     public Address execute(UUID id, UUID userProfileId) {
         return addressRepository.findByIdAndUserProfileId(id, userProfileId);

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/Update.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/Update.java
@@ -1,0 +1,18 @@
+package com.axconstantino.profile.application.address.service;
+
+import com.axconstantino.profile.application.address.command.UpdateAddressCommand;
+import com.axconstantino.profile.application.address.usecase.UpdateAddress;
+import com.axconstantino.profile.domain.repositories.AddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class Update implements UpdateAddress {
+    private final AddressRepository addressRepository;
+
+    @Override
+    public void execute(UpdateAddressCommand command) {
+        addressRepository.update(command.existingAddressId(), command.updatedAddress());
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/Update.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/service/Update.java
@@ -5,12 +5,14 @@ import com.axconstantino.profile.application.address.usecase.UpdateAddress;
 import com.axconstantino.profile.domain.repositories.AddressRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class Update implements UpdateAddress {
     private final AddressRepository addressRepository;
 
+    @Transactional
     @Override
     public void execute(UpdateAddressCommand command) {
         addressRepository.update(command.existingAddressId(), command.updatedAddress());

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/CreateAddress.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/CreateAddress.java
@@ -1,0 +1,7 @@
+package com.axconstantino.profile.application.address.usecase;
+
+import com.axconstantino.profile.application.address.command.CreateAddressCommand;
+
+public interface CreateAddress {
+    void execute(CreateAddressCommand command);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/DeleteAddress.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/DeleteAddress.java
@@ -1,0 +1,7 @@
+package com.axconstantino.profile.application.address.usecase;
+
+import java.util.UUID;
+
+public interface DeleteAddress {
+    void execute(UUID addressId);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/DeleteByAddressIdAndUserProfileId.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/DeleteByAddressIdAndUserProfileId.java
@@ -1,0 +1,7 @@
+package com.axconstantino.profile.application.address.usecase;
+
+import java.util.UUID;
+
+public interface DeleteByAddressIdAndUserProfileId {
+    void execute(UUID addressId, UUID userProfileId);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/GetAddressById.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/GetAddressById.java
@@ -1,0 +1,9 @@
+package com.axconstantino.profile.application.address.usecase;
+
+import com.axconstantino.profile.domain.entities.Address;
+
+import java.util.UUID;
+
+public interface GetAddressById {
+    Address execute(UUID id);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/GetAddressByIdAndUserProfileId.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/GetAddressByIdAndUserProfileId.java
@@ -1,0 +1,9 @@
+package com.axconstantino.profile.application.address.usecase;
+
+import com.axconstantino.profile.domain.entities.Address;
+
+import java.util.UUID;
+
+public interface GetAddressByIdAndUserProfileId {
+    Address execute(UUID id, UUID userProfileId);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/GetAllAddressesByUserProfileId.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/GetAllAddressesByUserProfileId.java
@@ -1,0 +1,10 @@
+package com.axconstantino.profile.application.address.usecase;
+
+import com.axconstantino.profile.domain.entities.Address;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface GetAllAddressesByUserProfileId {
+    List<Address> execute(UUID userProfileId);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/UpdateAddress.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/address/usecase/UpdateAddress.java
@@ -1,0 +1,8 @@
+package com.axconstantino.profile.application.address.usecase;
+
+import com.axconstantino.profile.application.address.command.UpdateAddressCommand;
+
+
+public interface UpdateAddress {
+    void execute(UpdateAddressCommand command);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/command/CreateProfileCommand.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/command/CreateProfileCommand.java
@@ -1,0 +1,6 @@
+package com.axconstantino.profile.application.profile.command;
+
+import com.axconstantino.profile.domain.entities.UserProfile;
+
+public record CreateProfileCommand(UserProfile profile) {
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/command/UpdateProfileCommand.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/command/UpdateProfileCommand.java
@@ -1,0 +1,13 @@
+package com.axconstantino.profile.application.profile.command;
+
+import com.axconstantino.profile.domain.entities.UserProfile;
+
+import java.util.UUID;
+
+public record UpdateProfileCommand(UUID existingProfileId, UserProfile updatedProfile) {
+    public UpdateProfileCommand {
+        if (existingProfileId == null || updatedProfile == null) {
+            throw new IllegalArgumentException("Existing profile ID and updated profile cannot be null");
+        }
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/service/CreateUserProfile.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/service/CreateUserProfile.java
@@ -1,0 +1,20 @@
+package com.axconstantino.profile.application.profile.service;
+
+import com.axconstantino.profile.application.profile.command.CreateProfileCommand;
+import com.axconstantino.profile.application.profile.usecase.CreateProfile;
+import com.axconstantino.profile.domain.repositories.UserProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreateUserProfile implements CreateProfile {
+    private final UserProfileRepository repository;
+
+    @Transactional
+    @Override
+    public void execute(CreateProfileCommand command) {
+        repository.save(command.profile());
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/service/DeleteProfileByKeycloak.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/service/DeleteProfileByKeycloak.java
@@ -1,0 +1,19 @@
+package com.axconstantino.profile.application.profile.service;
+
+import com.axconstantino.profile.application.profile.usecase.DeleteProfileByKeycloakId;
+import com.axconstantino.profile.domain.repositories.UserProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteProfileByKeycloak implements DeleteProfileByKeycloakId {
+    private final UserProfileRepository repository;
+
+    @Transactional
+    @Override
+    public void execute(String keycloakId) {
+        repository.deleteByKeycloakId(keycloakId);
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/service/DeleteUserProfile.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/service/DeleteUserProfile.java
@@ -1,0 +1,21 @@
+package com.axconstantino.profile.application.profile.service;
+
+import com.axconstantino.profile.application.profile.usecase.DeleteProfile;
+import com.axconstantino.profile.domain.repositories.UserProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteUserProfile implements DeleteProfile {
+    private final UserProfileRepository repository;
+
+    @Transactional
+    @Override
+    public void execute(UUID profileId) {
+        repository.delete(profileId);
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/service/GetProfile.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/service/GetProfile.java
@@ -1,0 +1,22 @@
+package com.axconstantino.profile.application.profile.service;
+
+import com.axconstantino.profile.application.profile.usecase.GetProfileById;
+import com.axconstantino.profile.domain.entities.UserProfile;
+import com.axconstantino.profile.domain.repositories.UserProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GetProfile implements GetProfileById {
+    private final UserProfileRepository repository;
+
+    @Transactional
+    @Override
+    public UserProfile execute(UUID profileId) {
+        return repository.findById(profileId);
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/service/GetProfileByKeycloak.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/service/GetProfileByKeycloak.java
@@ -1,0 +1,20 @@
+package com.axconstantino.profile.application.profile.service;
+
+import com.axconstantino.profile.application.profile.usecase.GetProfileByKeycloakId;
+import com.axconstantino.profile.domain.entities.UserProfile;
+import com.axconstantino.profile.domain.repositories.UserProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GetProfileByKeycloak implements GetProfileByKeycloakId {
+    private final UserProfileRepository repository;
+
+    @Transactional
+    @Override
+    public UserProfile execute(String keycloakId) {
+        return repository.findByKeycloakId(keycloakId);
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/service/Update.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/service/Update.java
@@ -1,0 +1,20 @@
+package com.axconstantino.profile.application.profile.service;
+
+import com.axconstantino.profile.application.profile.command.UpdateProfileCommand;
+import com.axconstantino.profile.application.profile.usecase.UpdateProfile;
+import com.axconstantino.profile.domain.repositories.UserProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class Update implements UpdateProfile {
+    private final UserProfileRepository repository;
+
+    @Transactional
+    @Override
+    public void execute(UpdateProfileCommand command) {
+        repository.update(command.existingProfileId(), command.updatedProfile());
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/usecase/CreateProfile.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/usecase/CreateProfile.java
@@ -1,0 +1,7 @@
+package com.axconstantino.profile.application.profile.usecase;
+
+import com.axconstantino.profile.application.profile.command.CreateProfileCommand;
+
+public interface CreateProfile {
+    void execute(CreateProfileCommand command);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/usecase/DeleteProfile.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/usecase/DeleteProfile.java
@@ -1,0 +1,7 @@
+package com.axconstantino.profile.application.profile.usecase;
+
+import java.util.UUID;
+
+public interface DeleteProfile {
+    void execute(UUID profileId);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/usecase/DeleteProfileByKeycloakId.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/usecase/DeleteProfileByKeycloakId.java
@@ -1,0 +1,5 @@
+package com.axconstantino.profile.application.profile.usecase;
+
+public interface DeleteProfileByKeycloakId {
+    void execute(String keycloakId);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/usecase/GetProfileById.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/usecase/GetProfileById.java
@@ -1,0 +1,9 @@
+package com.axconstantino.profile.application.profile.usecase;
+
+import com.axconstantino.profile.domain.entities.UserProfile;
+
+import java.util.UUID;
+
+public interface GetProfileById {
+    UserProfile execute(UUID profileId);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/usecase/GetProfileByKeycloakId.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/usecase/GetProfileByKeycloakId.java
@@ -1,0 +1,7 @@
+package com.axconstantino.profile.application.profile.usecase;
+
+import com.axconstantino.profile.domain.entities.UserProfile;
+
+public interface GetProfileByKeycloakId {
+    UserProfile execute(String keycloakId);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/usecase/UpdateProfile.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/application/profile/usecase/UpdateProfile.java
@@ -1,0 +1,7 @@
+package com.axconstantino.profile.application.profile.usecase;
+
+import com.axconstantino.profile.application.profile.command.UpdateProfileCommand;
+
+public interface UpdateProfile {
+    void execute(UpdateProfileCommand command);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/entities/Address.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/entities/Address.java
@@ -1,0 +1,17 @@
+package com.axconstantino.profile.domain.entities;
+
+import java.util.UUID;
+
+public class Address {
+    private UUID id;
+    private UserProfile userProfile;
+    private AddressType addressType;
+    private String street;
+    private String streetNumber;
+    private String apartment;
+    private String city;
+    private String state;
+    private String country;
+    private String zipCode;
+    private boolean isDefault;
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/entities/AddressType.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/entities/AddressType.java
@@ -1,0 +1,7 @@
+package com.axconstantino.profile.domain.entities;
+
+public enum AddressType {
+    HOME,
+    WORK,
+    OTHER
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/entities/UserProfile.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/entities/UserProfile.java
@@ -1,0 +1,17 @@
+package com.axconstantino.profile.domain.entities;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public class UserProfile {
+    private UUID id;
+    private String keycloakId;
+    private String fullName;
+    private String nickname;
+    private String phoneNumber;
+    private String avatarUrl;
+    private List<Address> addresses;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/AddressRepository.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/AddressRepository.java
@@ -11,6 +11,6 @@ public interface AddressRepository {
     List<Address> findByUserProfileId(UUID userProfileId);
     Address findByIdAndUserProfileId(UUID id, UUID userProfileId);
     void deleteByIdAndUserProfileId(UUID id, UUID userProfileId);
-    void update(Address address);
+    void update(UUID existingAddress, Address newAddress);
     void delete(UUID id);
 }

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/AddressRepository.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/AddressRepository.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 public interface AddressRepository {
     void save(Address address);
     Address findById(UUID id);
-    List<Address> findByUserProfileId(UUID userProfileId);
+    List<Address> findAllByUserProfileId(UUID userProfileId);
     Address findByIdAndUserProfileId(UUID id, UUID userProfileId);
     void deleteByIdAndUserProfileId(UUID id, UUID userProfileId);
     void update(UUID existingAddress, Address newAddress);

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/AddressRepository.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/AddressRepository.java
@@ -9,6 +9,8 @@ public interface AddressRepository {
     void save(Address address);
     Address findById(UUID id);
     List<Address> findByUserProfileId(UUID userProfileId);
+    Address findByIdAndUserProfileId(UUID id, UUID userProfileId);
+    void deleteByIdAndUserProfileId(UUID id, UUID userProfileId);
     void update(Address address);
     void delete(UUID id);
 }

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/AddressRepository.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/AddressRepository.java
@@ -1,0 +1,14 @@
+package com.axconstantino.profile.domain.repositories;
+
+import com.axconstantino.profile.domain.entities.Address;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AddressRepository {
+    void save(Address address);
+    Address findById(UUID id);
+    List<Address> findByUserProfileId(UUID userProfileId);
+    void update(Address address);
+    void delete(UUID id);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/UserProfileRepository.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/UserProfileRepository.java
@@ -10,6 +10,6 @@ public interface UserProfileRepository {
     UserProfile findByKeycloakId(String keycloakId);
     boolean existsByKeycloakId(String keycloakId);
     void deleteByKeycloakId(String keycloakId);
-    void update(UserProfile userProfile);
+    void update(UUID existingProfileId, UserProfile userProfile);
     void delete(UUID id);
 }

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/UserProfileRepository.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/UserProfileRepository.java
@@ -1,0 +1,13 @@
+package com.axconstantino.profile.domain.repositories;
+
+import com.axconstantino.profile.domain.entities.UserProfile;
+
+import java.util.UUID;
+
+public interface UserProfileRepository {
+    void save(UserProfile userProfile);
+    UserProfile findById(UUID id);
+    UserProfile findByKeycloakId(String keycloakId);
+    void update(UserProfile userProfile);
+    void delete(UUID id);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/UserProfileRepository.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/domain/repositories/UserProfileRepository.java
@@ -8,6 +8,8 @@ public interface UserProfileRepository {
     void save(UserProfile userProfile);
     UserProfile findById(UUID id);
     UserProfile findByKeycloakId(String keycloakId);
+    boolean existsByKeycloakId(String keycloakId);
+    void deleteByKeycloakId(String keycloakId);
     void update(UserProfile userProfile);
     void delete(UUID id);
 }

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/exception/NotFoundException.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.axconstantino.profile.exception;
+
+import java.io.Serial;
+
+public class NotFoundException extends RuntimeException {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/mapper/AddressJpaMapper.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/mapper/AddressJpaMapper.java
@@ -1,0 +1,20 @@
+package com.axconstantino.profile.infrastructure.mapper;
+
+import com.axconstantino.profile.domain.entities.Address;
+import com.axconstantino.profile.infrastructure.persistence.jpa.entities.AddressEntity;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface AddressJpaMapper {
+    AddressEntity toEntity(Address address);
+    Address toDomain(AddressEntity addressEntity);
+    List<Address> toDomain(List<AddressEntity> addressEntities);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntity(@MappingTarget AddressEntity addressEntity, Address address);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/mapper/UserProfileJpaMapper.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/mapper/UserProfileJpaMapper.java
@@ -1,0 +1,18 @@
+package com.axconstantino.profile.infrastructure.mapper;
+
+import com.axconstantino.profile.domain.entities.UserProfile;
+import com.axconstantino.profile.infrastructure.persistence.jpa.entities.UserProfileEntity;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+
+@Mapper(componentModel = "spring")
+public interface UserProfileJpaMapper {
+    UserProfileEntity toEntity(UserProfile profile);
+    UserProfile toDomain(UserProfileEntity profileEntity);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntity(@MappingTarget UserProfileEntity userProfileEntity, UserProfile userProfile);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/adapter/AddressRepositoryImpl.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/adapter/AddressRepositoryImpl.java
@@ -32,7 +32,7 @@ public class AddressRepositoryImpl implements AddressRepository {
     }
 
     @Override
-    public List<Address> findByUserProfileId(UUID userProfileId) {
+    public List<Address> findAllByUserProfileId(UUID userProfileId) {
         var addressEntities = addressJpa.findAllByUserProfileId(userProfileId);
         return mapper.toDomain(addressEntities);
     }

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/adapter/AddressRepositoryImpl.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/adapter/AddressRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.axconstantino.profile.infrastructure.persistence.adapter;
+
+import com.axconstantino.profile.domain.entities.Address;
+import com.axconstantino.profile.domain.repositories.AddressRepository;
+import com.axconstantino.profile.exception.NotFoundException;
+import com.axconstantino.profile.infrastructure.mapper.AddressJpaMapper;
+import com.axconstantino.profile.infrastructure.persistence.jpa.repositories.AddressJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class AddressRepositoryImpl implements AddressRepository {
+
+    private final AddressJpaRepository addressJpa;
+    private final AddressJpaMapper mapper;
+
+    @Override
+    public void save(Address address) {
+        var addressEntity = mapper.toEntity(address);
+        addressJpa.save(addressEntity);
+    }
+
+    @Override
+    public Address findById(UUID id) {
+        var addressEntity = addressJpa.findById(id)
+                .orElseThrow(() -> new NotFoundException("Not found address with id: " + id));
+        return mapper.toDomain(addressEntity);
+    }
+
+    @Override
+    public List<Address> findByUserProfileId(UUID userProfileId) {
+        var addressEntities = addressJpa.findAllByUserProfileId(userProfileId);
+        return mapper.toDomain(addressEntities);
+    }
+
+    @Override
+    public Address findByIdAndUserProfileId(UUID id, UUID userProfileId) {
+        var addressEntity = addressJpa.findByIdAndUserProfileId(id, userProfileId)
+                .orElseThrow(() -> new NotFoundException("Not found address with id: " + id + " and user profile id: " + userProfileId));
+        return mapper.toDomain(addressEntity);
+    }
+
+    @Override
+    public void deleteByIdAndUserProfileId(UUID id, UUID userProfileId) {
+        addressJpa.deleteByIdAndUserProfileId(id, userProfileId);
+    }
+
+    @Override
+    public void update(UUID existingAddress, Address newAddress) {
+        var addressEntity = addressJpa.findById(existingAddress)
+                .orElseThrow(() -> new NotFoundException("Not found address with id: " + existingAddress));
+        mapper.updateEntity(addressEntity, newAddress);
+    }
+
+    @Override
+    public void delete(UUID id) {
+        addressJpa.deleteById(id);
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/adapter/UserProfileRepositoryImpl.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/adapter/UserProfileRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.axconstantino.profile.infrastructure.persistence.adapter;
+
+import com.axconstantino.profile.domain.entities.UserProfile;
+import com.axconstantino.profile.domain.repositories.UserProfileRepository;
+import com.axconstantino.profile.exception.NotFoundException;
+import com.axconstantino.profile.infrastructure.mapper.UserProfileJpaMapper;
+import com.axconstantino.profile.infrastructure.persistence.jpa.repositories.UserProfileJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class UserProfileRepositoryImpl implements UserProfileRepository {
+    private final UserProfileJpaRepository userProfileJpa;
+    private final UserProfileJpaMapper mapper;
+
+    @Override
+    public void save(UserProfile userProfile) {
+        var userProfileEntity = mapper.toEntity(userProfile);
+        userProfileJpa.save(userProfileEntity);
+    }
+
+    @Override
+    public UserProfile findById(UUID id) {
+        var userProfileEntity = userProfileJpa.findById(id)
+                .orElseThrow(() -> new NotFoundException("Not found user profile with id: " + id));
+        return mapper.toDomain(userProfileEntity);
+    }
+
+    @Override
+    public UserProfile findByKeycloakId(String keycloakId) {
+        var userProfileEntity = userProfileJpa.findByKeycloakId(keycloakId)
+                .orElseThrow(() -> new NotFoundException("Not found user profile with keycloak id: " + keycloakId));
+        return mapper.toDomain(userProfileEntity);
+    }
+
+    @Override
+    public boolean existsByKeycloakId(String keycloakId) {
+        return userProfileJpa.existsByKeycloakId(keycloakId);
+    }
+
+    @Override
+    public void deleteByKeycloakId(String keycloakId) {
+        userProfileJpa.deleteByKeycloakId(keycloakId);
+    }
+
+    @Override
+    public void update(UUID existingProfileId, UserProfile userProfile) {
+        var userProfileEntity = userProfileJpa.findById(existingProfileId)
+                .orElseThrow(() -> new NotFoundException("Not found user profile with id: " + existingProfileId));
+        mapper.updateEntity(userProfileEntity, userProfile);
+    }
+
+    @Override
+    public void delete(UUID id) {
+        userProfileJpa.deleteById(id);
+    }
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/jpa/entities/AddressEntity.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/jpa/entities/AddressEntity.java
@@ -1,0 +1,54 @@
+package com.axconstantino.profile.infrastructure.persistence.jpa.entities;
+
+import com.axconstantino.profile.domain.entities.AddressType;
+import com.axconstantino.profile.domain.entities.UserProfile;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "address")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class AddressEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_profile_id", nullable = false)
+    private UserProfile userProfile;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "address_type")
+    private AddressType addressType;
+
+    @Column(nullable = false)
+    private String street;
+
+    @Column(name = "street_number", nullable = false)
+    private String streetNumber;
+
+    private String apartment;
+
+    @Column(nullable = false)
+    private String city;
+
+    @Column(nullable = false)
+    private String state;
+
+    @Column(nullable = false)
+    private String country;
+
+    @Column(name = "zip_code", nullable = false)
+    private String zipCode;
+
+    @Column(name = "is_default", nullable = false)
+    private boolean isDefault;
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/jpa/entities/UserProfileEntity.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/jpa/entities/UserProfileEntity.java
@@ -1,0 +1,58 @@
+package com.axconstantino.profile.infrastructure.persistence.jpa.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_profile")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class UserProfileEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "keycloak_id", nullable = false, unique = true)
+    private String keycloakId;
+
+    @Column(name = "full_name", nullable = false)
+    @NotBlank
+    @Size(max = 255, min = 2)
+    private String fullName;
+
+    @Column(name = "nickname", nullable = false)
+    @NotBlank
+    @Size(max = 255, min = 2)
+    private String nickname;
+
+    @Column(name = "phone_number", nullable = false)
+    private String phoneNumber;
+
+    @Column(name = "avatar_url")
+    private String avatarUrl;
+
+    @OneToMany(mappedBy = "userProfile", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AddressEntity> addresses;
+
+    @Column(name = "created_at", nullable = false)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/jpa/repositories/AddressJpaRepository.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/jpa/repositories/AddressJpaRepository.java
@@ -3,10 +3,12 @@ package com.axconstantino.profile.infrastructure.persistence.jpa.repositories;
 import com.axconstantino.profile.infrastructure.persistence.jpa.entities.AddressEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface AddressJpaRepository extends JpaRepository<AddressEntity, UUID> {
-    AddressEntity findByIdAndUserProfileId(UUID id, UUID userProfileId);
-
+    Optional<AddressEntity> findByIdAndUserProfileId(UUID id, UUID userProfileId);
+    List<AddressEntity> findAllByUserProfileId(UUID userProfileId);
     void deleteByIdAndUserProfileId(UUID id, UUID userProfileId);
 }

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/jpa/repositories/AddressJpaRepository.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/jpa/repositories/AddressJpaRepository.java
@@ -1,0 +1,12 @@
+package com.axconstantino.profile.infrastructure.persistence.jpa.repositories;
+
+import com.axconstantino.profile.infrastructure.persistence.jpa.entities.AddressEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface AddressJpaRepository extends JpaRepository<AddressEntity, UUID> {
+    AddressEntity findByIdAndUserProfileId(UUID id, UUID userProfileId);
+
+    void deleteByIdAndUserProfileId(UUID id, UUID userProfileId);
+}

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/jpa/repositories/UserProfileJpaRepository.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/jpa/repositories/UserProfileJpaRepository.java
@@ -3,11 +3,12 @@ package com.axconstantino.profile.infrastructure.persistence.jpa.repositories;
 import com.axconstantino.profile.infrastructure.persistence.jpa.entities.UserProfileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 
 public interface UserProfileJpaRepository extends JpaRepository<UserProfileEntity, UUID> {
-    UserProfileEntity findByKeycloakId(String keycloakId);
+    Optional<UserProfileEntity> findByKeycloakId(String keycloakId);
 
     void deleteByKeycloakId(String keycloakId);
 

--- a/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/jpa/repositories/UserProfileJpaRepository.java
+++ b/User-Profile-Service/src/main/java/com/axconstantino/profile/infrastructure/persistence/jpa/repositories/UserProfileJpaRepository.java
@@ -1,0 +1,15 @@
+package com.axconstantino.profile.infrastructure.persistence.jpa.repositories;
+
+import com.axconstantino.profile.infrastructure.persistence.jpa.entities.UserProfileEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+
+public interface UserProfileJpaRepository extends JpaRepository<UserProfileEntity, UUID> {
+    UserProfileEntity findByKeycloakId(String keycloakId);
+
+    void deleteByKeycloakId(String keycloakId);
+
+    boolean existsByKeycloakId(String keycloakId);
+}


### PR DESCRIPTION
🚀 Pull Request: Implement Address and UserProfile Feature
✅ Overview
This PR introduces the initial implementation of the Address and UserProfile modules, including domain, application, and infrastructure layers. The goal is to establish the foundational structure for handling addresses and user profiles using clean architecture principles.

🔧 What’s Included
Domain Layer:

Creation of core domain entities (Address, UserProfile)

Setup of domain repositories for each entity

Application Layer:

Use case definitions for Address handling

Command records for creating and querying data

Service implementations annotated with @Transactional for proper transaction management

Infrastructure Layer:

JPA entity mappings for Address and UserProfile

Persistence adapters using Spring Data JPA

Custom query: findAllByUserProfileId(UUID userProfileId)

🛠 Changes Summary
Address and UserProfile entities and repositories

JPA adapters and MapStruct mappers

Use cases and services for the Address context

Custom query and method implementation

Code is organized under appropriate packages (domain, application.profile, infrastructure.persistence)

📌 Notes
Services are marked as @Transactional to ensure data integrity

Commands and services follow the command-query responsibility separation (CQRS) style